### PR TITLE
Set Biarch flag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,3 +19,4 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
+Biarch: true


### PR DESCRIPTION
Added 'Biarch' field to force compilation 32/64 

Motivation 
"For a 32/64-bit installation of R on Windows, a small minority of packages with compiled code need either INSTALL_opts = "--force-biarch" or INSTALL_opts = "--merge-multiarch" for a source installation. (It is safe to always set the latter when installing from a repository or tarballs, although it will be a little slower.)"  [Source: https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/install.packages]